### PR TITLE
Adding functionality to delete/restart shovel on any node in cluster

### DIFF
--- a/deps/rabbitmq_shovel_management/priv/www/js/shovel.js
+++ b/deps/rabbitmq_shovel_management/priv/www/js/shovel.js
@@ -87,7 +87,7 @@ dispatcher_add(function(sammy) {
             if (sync_delete(this, '/shovels/vhost/:vhost/:name')) {
                 go_to('#/dynamic-shovels');
             } else {
-                show_popup('warn', 'Shovel not deleted because it is not running on this node.');
+                show_popup('warn', 'Shovel was not able to be deleted');
                 return false;
             }
         });
@@ -95,7 +95,7 @@ dispatcher_add(function(sammy) {
             if (sync_delete(this, '/shovels/vhost/:vhost/:name/restart')) {
                 update();
             } else {
-                show_popup('warn', 'Shovel not restarted because it is not running on this node.');
+                show_popup('warn', 'Shovel was not able to be restarted');
                 return false;
             }
         });

--- a/deps/rabbitmq_shovel_management/priv/www/js/shovel.js
+++ b/deps/rabbitmq_shovel_management/priv/www/js/shovel.js
@@ -87,7 +87,7 @@ dispatcher_add(function(sammy) {
             if (sync_delete(this, '/shovels/vhost/:vhost/:name')) {
                 go_to('#/dynamic-shovels');
             } else {
-                show_popup('warn', 'Shovel was not able to be deleted');
+                show_popup('warn', 'Shovel could not be deleted');
                 return false;
             }
         });
@@ -95,7 +95,7 @@ dispatcher_add(function(sammy) {
             if (sync_delete(this, '/shovels/vhost/:vhost/:name/restart')) {
                 update();
             } else {
-                show_popup('warn', 'Shovel was not able to be restarted');
+                show_popup('warn', 'Shovel could not be restarted');
                 return false;
             }
         });

--- a/deps/rabbitmq_shovel_management/src/rabbit_shovel_mgmt.erl
+++ b/deps/rabbitmq_shovel_management/src/rabbit_shovel_mgmt.erl
@@ -38,23 +38,23 @@ allowed_methods(ReqData, Context) ->
 
 resource_exists(ReqData, Context) ->
     Reply = case rabbit_mgmt_util:vhost(ReqData) of
-        not_found ->
-            false;
-        VHost ->
-            case rabbit_mgmt_util:id(name, ReqData) of
-                none -> true;
-                Name ->
-                    %% Deleting or restarting a shovel
-                    case get_shovel_node(VHost, Name, ReqData, Context) of
-                        undefined ->
-                            rabbit_log:error("Shovel with the name '~s' was not found on virtual host '~s'",
-                                             [Name, VHost]),
-                            false;
-                        _ ->
-                            true
+                not_found ->
+                    false;
+                VHost ->
+                    case rabbit_mgmt_util:id(name, ReqData) of
+                        none -> true;
+                        Name ->
+                            %% Deleting or restarting a shovel
+                            case get_shovel_node(VHost, Name, ReqData, Context) of
+                                undefined ->
+                                    rabbit_log:error("Shovel with the name '~s' was not found on virtual host '~s'",
+                                        [Name, VHost]),
+                                    false;
+                                _ ->
+                                    true
+                            end
                     end
-            end
-    end,
+            end,
     {Reply, ReqData, Context}.
 
 to_json(ReqData, Context) ->
@@ -67,20 +67,20 @@ is_authorized(ReqData, Context) ->
 delete_resource(ReqData, #context{user = #user{username = Username}}=Context) ->
     VHost = rabbit_mgmt_util:id(vhost, ReqData),
     Reply = case rabbit_mgmt_util:id(name, ReqData) of
-        none ->
-            false;
-        Name ->
-            case get_shovel_node(VHost, Name, ReqData, Context) of
-                undefined -> rabbit_log:error("Could not find shovel data for shovel '~s' in vhost: '~s'", [Name, VHost]),
+                none ->
                     false;
-                Node ->
-                    %% We must distinguish between a delete and restart
-                    case is_restart(ReqData) of
-                        true -> restart_shovel(VHost, Name, Node);
-                        _ -> delete_shovel(VHost, Name, Node, Username)
+                Name ->
+                    case get_shovel_node(VHost, Name, ReqData, Context) of
+                        undefined -> rabbit_log:error("Could not find shovel data for shovel '~s' in vhost: '~s'", [Name, VHost]),
+                            false;
+                        Node ->
+                            %% We must distinguish between a delete and restart
+                            case is_restart(ReqData) of
+                                true -> restart_shovel(VHost, Name, Node);
+                                _ -> delete_shovel(VHost, Name, Node, Username)
+                            end
                     end
-            end
-    end,
+            end,
     {Reply, ReqData, Context}.
 
 %%--------------------------------------------------------------------

--- a/deps/rabbitmq_shovel_management/src/rabbit_shovel_mgmt.erl
+++ b/deps/rabbitmq_shovel_management/src/rabbit_shovel_mgmt.erl
@@ -38,23 +38,23 @@ allowed_methods(ReqData, Context) ->
 
 resource_exists(ReqData, Context) ->
     Reply = case rabbit_mgmt_util:vhost(ReqData) of
-                not_found ->
-                    false;
-                VHost ->
-                    case rabbit_mgmt_util:id(name, ReqData) of
-                        none -> true;
-                        Name ->
-                            %% Deleting or restarting a shovel
-                            case get_shovel_data(VHost, Name, ReqData, Context) of
-                                [] ->
-                                    rabbit_log:error("Shovel with the name '~s' was not found on virtual host '~s'",
-                                                     [Name, VHost]),
-                                    false;
-                                _ ->
-                                    true
-                            end
+        not_found ->
+            false;
+        VHost ->
+            case rabbit_mgmt_util:id(name, ReqData) of
+                none -> true;
+                Name ->
+                    %% Deleting or restarting a shovel
+                    case get_shovel_node(VHost, Name, ReqData, Context) of
+                        undefined ->
+                            rabbit_log:error("Shovel with the name '~s' was not found on virtual host '~s'",
+                                             [Name, VHost]),
+                            false;
+                        _ ->
+                            true
                     end
-            end,
+            end
+    end,
     {Reply, ReqData, Context}.
 
 to_json(ReqData, Context) ->
@@ -67,25 +67,20 @@ is_authorized(ReqData, Context) ->
 delete_resource(ReqData, #context{user = #user{username = Username}}=Context) ->
     VHost = rabbit_mgmt_util:id(vhost, ReqData),
     Reply = case rabbit_mgmt_util:id(name, ReqData) of
-                none ->
+        none ->
+            false;
+        Name ->
+            case get_shovel_node(VHost, Name, ReqData, Context) of
+                undefined -> rabbit_log:error("Could not find shovel data for shovel '~s' in vhost: '~s'", [Name, VHost]),
                     false;
-                Name ->
-                  case get_shovel_data(VHost, Name, ReqData, Context) of
-                    [] ->
-                      rabbit_log:error("Could not find shovel data for shovel ~s in vhost: ~s", [Name, VHost]),
-                      false;
-                    ShovelData ->
-                      {_,Node}=lists:keyfind(node, 1, lists:nth(1, ShovelData)),
-                      %% We must distinguish between a delete and restart
-                      case is_restart(ReqData) of
-                        true ->
-                          restart_shovel(VHost, Name, Node);
-                        _ ->
-                          delete_shovel(VHost, Name, Node, Username)
-                      end
-
-                  end
-            end,
+                Node ->
+                    %% We must distinguish between a delete and restart
+                    case is_restart(ReqData) of
+                        true -> restart_shovel(VHost, Name, Node);
+                        _ -> delete_shovel(VHost, Name, Node, Username)
+                    end
+            end
+    end,
     {Reply, ReqData, Context}.
 
 %%--------------------------------------------------------------------
@@ -115,32 +110,28 @@ filter_vhost_user(List, _ReqData, #context{user = User = #user{tags = Tags}}) ->
                      end].
 
 restart_shovel(VHost, Name, Node) ->
-      case rpc:call(Node, rabbit_shovel_util, restart_shovel, [VHost, Name], infinity) of
-        {badrpc, Reason} ->
-          rabbit_log:error("rabbit_shovel_util Could not restart_shovel ~s in vhost ~s Reason: ~s", [Name, VHost, Reason]),
-          false;
-        {error, ErrorMsg} ->
-          rabbit_log:error("Could not restart shovel ~s in vhost ~s with error message: ~s", [Name, VHost, ErrorMsg]),
-          false;
-        ok -> true
-      end.
+    rabbit_log:info("Calling rabbit_shovel_util:restart_shovel on Node '~s' for shovel '~s' in vhost '~s'", [Node, Name, VHost]),
+    case rpc:call(Node, rabbit_shovel_util, restart_shovel, [VHost, Name], infinity) of
+        ok -> true;
+        {_, msg} -> rabbit_log:error(msg)
+    end.
 
 delete_shovel(VHost, Name, Node, Username) ->
-  case rpc:call(Node, rabbit_shovel_util, delete_shovel, [VHost, Name, Username], infinity) of
-    {badrpc, Reason} ->
-      rabbit_log:error("rabbit_shovel_util Could not delete_shovel ~s in vhost ~s Reason: ~s", [Name, VHost, Reason]),
-      false;
-    {error, ErrorMsg} ->
-      rabbit_log:error("Could not delete shovel ~s in vhost ~s with error message: ~s", [Name, VHost, ErrorMsg]),
-      false;
-    ok -> true
-  end.
+    rabbit_log:info("Calling rabbit_shovel_util:delete_shovel on Node '~s' for shovel '~s' in vhost '~s'", [Node, Name, VHost]),
+    case rpc:call(Node, rabbit_shovel_util, delete_shovel, [VHost, Name, Username], infinity) of
+        ok -> true;
+        {_, msg} -> rabbit_log:error(msg)
+    end.
 
-get_shovel_data(VHost, Name, ReqData, Context) ->
-    AllShovels = filter_vhost_user(
-      lists:append([status(Node) || Node <- [node() | nodes()]]),
-      ReqData, Context),
-    lists:filter(fun (Shovel) -> lists:member({name, Name}, Shovel) and lists:member({vhost, VHost}, Shovel) end, AllShovels).
+get_shovel_node(VHost, Name, ReqData, Context) ->
+    AllShovels = status(ReqData, Context),
+    MatchedShovel = lists:filter(fun (Shovel) ->
+        lists:member({name, Name}, Shovel) and lists:member({vhost, VHost}, Shovel) end, AllShovels),
+    case MatchedShovel of
+        [] -> undefined;
+        ShovelData -> {_,Node}=lists:keyfind(node, 1, lists:nth(1, ShovelData)),
+            Node
+    end.
 
 status(ReqData, Context) ->
     filter_vhost_user(

--- a/deps/rabbitmq_shovel_management/src/rabbit_shovel_mgmt.erl
+++ b/deps/rabbitmq_shovel_management/src/rabbit_shovel_mgmt.erl
@@ -113,14 +113,16 @@ restart_shovel(VHost, Name, Node) ->
     rabbit_log:info("Calling rabbit_shovel_util:restart_shovel on Node '~s' for shovel '~s' in vhost '~s'", [Node, Name, VHost]),
     case rpc:call(Node, rabbit_shovel_util, restart_shovel, [VHost, Name], infinity) of
         ok -> true;
-        {_, msg} -> rabbit_log:error(msg)
+        {_, msg} -> rabbit_log:error(msg),
+            false
     end.
 
 delete_shovel(VHost, Name, Node, Username) ->
     rabbit_log:info("Calling rabbit_shovel_util:delete_shovel on Node '~s' for shovel '~s' in vhost '~s'", [Node, Name, VHost]),
     case rpc:call(Node, rabbit_shovel_util, delete_shovel, [VHost, Name, Username], infinity) of
         ok -> true;
-        {_, msg} -> rabbit_log:error(msg)
+        {_, msg} -> rabbit_log:error(msg),
+            false
     end.
 
 get_shovel_node(VHost, Name, ReqData, Context) ->

--- a/deps/rabbitmq_shovel_management/src/rabbit_shovel_mgmt_util.erl
+++ b/deps/rabbitmq_shovel_management/src/rabbit_shovel_mgmt_util.erl
@@ -1,0 +1,66 @@
+%% This Source Code Form is subject to the terms of the Mozilla Public
+%% License, v. 2.0. If a copy of the MPL was not distributed with this
+%% file, You can obtain one at https://mozilla.org/MPL/2.0/.
+%%
+%% Copyright (c) 2007-2021 VMware, Inc. or its affiliates.  All rights reserved.
+%%
+
+-module(rabbit_shovel_mgmt_util).
+
+-export([status/2]).
+
+-import(rabbit_misc, [pget/2]).
+
+-include_lib("rabbitmq_management_agent/include/rabbit_mgmt_records.hrl").
+-include_lib("amqp_client/include/amqp_client.hrl").
+
+
+%% Allow users to see things in the vhosts they are authorised. But
+%% static shovels do not have a vhost, so only allow admins (not
+%% monitors) to see them.
+filter_vhost_user(List, _ReqData, #context{user = User = #user{tags = Tags}}) ->
+    VHosts = rabbit_mgmt_util:list_login_vhosts_names(User, undefined),
+    [I || I <- List, case pget(vhost, I) of
+                         undefined -> lists:member(administrator, Tags);
+                         VHost     -> lists:member(VHost, VHosts)
+                     end].
+
+status(ReqData, Context) ->
+    filter_vhost_user(
+        lists:append([status(Node) || Node <- [node() | nodes()]]),
+        ReqData, Context).
+
+status(Node) ->
+    case rpc:call(Node, rabbit_shovel_status, status, [], infinity) of
+        {badrpc, {'EXIT', _}} ->
+            [];
+        Status ->
+            [format(Node, I) || I <- Status]
+    end.
+
+format(Node, {Name, Type, Info, TS}) ->
+    [{node, Node}, {timestamp, format_ts(TS)}] ++
+        format_name(Type, Name) ++
+        format_info(Info).
+
+format_name(static,  Name)          -> [{name,  Name},
+    {type,  static}];
+format_name(dynamic, {VHost, Name}) -> [{name,  Name},
+    {vhost, VHost},
+    {type,  dynamic}].
+
+format_info(starting) ->
+    [{state, starting}];
+
+format_info({running, Props}) ->
+    [{state, running}] ++ Props;
+
+format_info({terminated, Reason}) ->
+    [{state,  terminated},
+        {reason, print("~p", [Reason])}].
+
+format_ts({{Y, M, D}, {H, Min, S}}) ->
+    print("~w-~2.2.0w-~2.2.0w ~w:~2.2.0w:~2.2.0w", [Y, M, D, H, Min, S]).
+
+print(Fmt, Val) ->
+    list_to_binary(io_lib:format(Fmt, Val)).

--- a/deps/rabbitmq_shovel_management/test/rabbit_shovel_mgmt_SUITE.erl
+++ b/deps/rabbitmq_shovel_management/test/rabbit_shovel_mgmt_SUITE.erl
@@ -56,18 +56,18 @@ get_shovel_node_shovel_different_name(_Config) ->
     Name= <<"shovelThatDoesntExist">>,
     User = #user{username="admin",tags = [administrator]},
     Node = rabbit_shovel_mgmt:get_shovel_node(VHost, Name, {}, #context{user = User}),
-    ?assertEqual(Node, undefined).
+    ?assertEqual(undefined, Node).
 
 get_shovel_node_shovel_different_vhost_name(_Config) ->
     VHost = <<"VHostThatDoesntExist">>,
     Name= <<"shovel1">>,
     User = #user{username="admin",tags = [administrator]},
     Node = rabbit_shovel_mgmt:get_shovel_node(VHost, Name, {}, #context{user = User}),
-    ?assertEqual(Node, undefined).
+    ?assertEqual(undefined, Node).
 
 get_shovel_node_shovel_found(_Config) ->
     VHost = <<"otherVhost">>,
     Name= <<"shovel2">>,
     User = #user{username="admin",tags = [administrator]},
     Node = rabbit_shovel_mgmt:get_shovel_node(VHost, Name, {}, #context{user = User}),
-    ?assertEqual(Node, 'node2').
+    ?assertEqual('node2', Node).

--- a/deps/rabbitmq_shovel_management/test/rabbit_shovel_mgmt_SUITE.erl
+++ b/deps/rabbitmq_shovel_management/test/rabbit_shovel_mgmt_SUITE.erl
@@ -1,0 +1,73 @@
+-module(rabbit_shovel_mgmt_SUITE).
+
+-include_lib("common_test/include/ct.hrl").
+-include_lib("eunit/include/eunit.hrl").
+-include_lib("rabbit_common/include/rabbit.hrl").
+-include_lib("rabbitmq_management_agent/include/rabbit_mgmt_records.hrl").
+
+-compile(export_all).
+
+-define(MOCK_SHOVELS,
+    [[
+        {node,'node1'},
+        {name,<<"shovel1">>},
+        {vhost,<<"/">>},
+        {type,dynamic},
+        {state,running},
+        {src_uri,<<"amqp://">>},
+        {src_protocol,<<"amqp091">>},
+        {dest_protocol,<<"amqp091">>},
+        {dest_uri,<<"amqp://">>},
+        {src_queue,<<"q1">>},
+        {dest_queue,<<"q2">>}
+    ],
+    [
+        {node,'node2'},
+        {name,<<"shovel2">>},
+        {vhost,<<"otherVhost">>},
+        {type,dynamic},
+        {state,running},
+        {src_uri,<<"amqp://">>},
+        {src_protocol,<<"amqp091">>},
+        {dest_protocol,<<"amqp091">>},
+        {dest_uri,<<"amqp://">>},
+        {src_queue,<<"q1">>},
+        {dest_queue,<<"q2">>}
+    ]]).
+
+all() ->
+    [
+        get_shovel_node_shovel_different_name,
+        get_shovel_node_shovel_different_vhost_name,
+        get_shovel_node_shovel_found
+    ].
+
+init_per_testcase(_, _Config) ->
+    meck:new(rabbit_shovel_mgmt_util),
+    meck:expect(rabbit_shovel_mgmt_util, status, fun(_,_) -> ?MOCK_SHOVELS end),
+    _Config.
+
+end_per_testcase(_, _Config) ->
+    meck:unload(rabbit_shovel_mgmt_util),
+    _Config.
+
+get_shovel_node_shovel_different_name(_Config) ->
+    VHost = <<"otherVhost">>,
+    Name= <<"shovelThatDoesntExist">>,
+    User = #user{username="admin",tags = [administrator]},
+    Node = rabbit_shovel_mgmt:get_shovel_node(VHost, Name, {}, #context{user = User}),
+    ?assertEqual(Node, undefined).
+
+get_shovel_node_shovel_different_vhost_name(_Config) ->
+    VHost = <<"VHostThatDoesntExist">>,
+    Name= <<"shovel1">>,
+    User = #user{username="admin",tags = [administrator]},
+    Node = rabbit_shovel_mgmt:get_shovel_node(VHost, Name, {}, #context{user = User}),
+    ?assertEqual(Node, undefined).
+
+get_shovel_node_shovel_found(_Config) ->
+    VHost = <<"otherVhost">>,
+    Name= <<"shovel2">>,
+    User = #user{username="admin",tags = [administrator]},
+    Node = rabbit_shovel_mgmt:get_shovel_node(VHost, Name, {}, #context{user = User}),
+    ?assertEqual(Node, 'node2').


### PR DESCRIPTION
## Proposed Changes

Currently, shovels on nodes not the target node that the user is connected to are not able to be deleted. see issue: 
https://github.com/rabbitmq/rabbitmq-server/issues/2807

This change adds functionality to locate node that shovel is running on, and call rpc:call to delete/restart shovel on that node.

## Types of Changes

What types of changes does your code introduce to this project?
_Put an `x` in the boxes that apply_

- [x] Bug fix (non-breaking change which fixes issue #NNNN)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause an observable behavior change in existing systems)
- [ ] Documentation improvements (corrections, new content, etc)
- [ ] Cosmetic change (whitespace, formatting, etc)
- [ ] Build system and/or CI

## Checklist

_Put an `x` in the boxes that apply.
You can also fill these out after creating the PR.
If you're unsure about any of them, don't hesitate to ask on the mailing list.
We're here to help!
This is simply a reminder of what we are going to look for before merging your code._

- [x] I have read the `CONTRIBUTING.md` document
- [x] I have signed the CA (see https://cla.pivotal.io/sign/rabbitmq)
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] All tests pass locally with my changes
- [ ] If relevant, I have added necessary documentation to https://github.com/rabbitmq/rabbitmq-website
- [ ] If relevant, I have added this change to the first version(s) in release-notes that I expect to introduce it

## Further Comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc.
